### PR TITLE
specify column types by string

### DIFF
--- a/_examples/helloworld/helloworld.go
+++ b/_examples/helloworld/helloworld.go
@@ -37,9 +37,9 @@ func (i *Iter) Next() (vtab.Row, error) {
 }
 
 var cols = []vtab.Column{
-	{"message", sqlite.SQLITE_TEXT, false, false, nil, vtab.NONE},
-	{"times", sqlite.SQLITE_INTEGER, false, true, []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}, vtab.NONE},
-	{"name", sqlite.SQLITE_TEXT, false, true, []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}, vtab.NONE},
+	{"message", "TEXT", false, false, nil, vtab.NONE},
+	{"times", "INTEGER", false, true, []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}, vtab.NONE},
+	{"name", "TEXT", false, true, []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}, vtab.NONE},
 }
 
 func init() {

--- a/series_test.go
+++ b/series_test.go
@@ -56,10 +56,10 @@ func (i *seriesIter) Next() (vtab.Row, error) {
 
 func TestSeries(t *testing.T) {
 	cols := []vtab.Column{
-		{Name: "value", Type: sqlite.SQLITE_INTEGER, OrderBy: vtab.ASC | vtab.DESC},
-		{Name: "start", Type: sqlite.SQLITE_INTEGER, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}},
-		{Name: "stop", Type: sqlite.SQLITE_INTEGER, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}},
-		{Name: "step", Type: sqlite.SQLITE_INTEGER, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}},
+		{Name: "value", Type: "INTEGER", OrderBy: vtab.ASC | vtab.DESC},
+		{Name: "start", Type: "INTEGER", Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}},
+		{Name: "stop", Type: "INTEGER", Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}},
+		{Name: "step", Type: "INTEGER", Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}},
 	}
 	m := vtab.NewTableFunc("series", cols, func(constraints []*vtab.Constraint, order []*sqlite.OrderBy) (vtab.Iterator, error) {
 		// defaults

--- a/vtab.go
+++ b/vtab.go
@@ -11,23 +11,6 @@ import (
 	"go.riyazali.net/sqlite"
 )
 
-func ColTypeSQLString(t sqlite.ColumnType) string {
-	switch t {
-	case sqlite.SQLITE_INTEGER:
-		return "INTEGER"
-	case sqlite.SQLITE_FLOAT:
-		return "FLOAT"
-	case sqlite.SQLITE_TEXT:
-		return "TEXT"
-	case sqlite.SQLITE_BLOB:
-		return "BLOB"
-	case sqlite.SQLITE_NULL:
-		return "NULL"
-	default:
-		return "<unknown sqlite datatype>"
-	}
-}
-
 type Orders uint8
 
 const (
@@ -44,15 +27,11 @@ type ColumnFilter struct {
 
 type Column struct {
 	Name    string
-	Type    sqlite.ColumnType
+	Type    string
 	NotNull bool
 	Hidden  bool
 	Filters []*ColumnFilter
 	OrderBy Orders
-}
-
-func (c Column) SQLType() string {
-	return ColTypeSQLString(c.Type)
 }
 
 type Constraint struct {
@@ -97,7 +76,7 @@ func (m *tableFuncModule) createTableSQL() (string, error) {
 	// TODO needs to support WITHOUT ROWID, PRIMARY KEY, NOT NULL
 	const declare = `CREATE TABLE {{ .Name }} (
   {{- range $c, $col := .Columns }}
-    {{ .Name }} {{ .SQLType }}{{ if .Hidden }} HIDDEN{{ end }}{{ if columnComma $c }},{{ end }}
+    {{ .Name }} {{ .Type }}{{ if .Hidden }} HIDDEN{{ end }}{{ if columnComma $c }},{{ end }}
   {{- end }}
 )`
 

--- a/vtab_test.go
+++ b/vtab_test.go
@@ -2,18 +2,16 @@ package vtab
 
 import (
 	"testing"
-
-	"go.riyazali.net/sqlite"
 )
 
 func TestCreateTableSQL(t *testing.T) {
 	m := &tableFuncModule{
 		name: "test_table",
 		columns: []Column{
-			{Name: "test_one", Type: sqlite.SQLITE_TEXT},
-			{Name: "test_two", Type: sqlite.SQLITE_INTEGER},
-			{Name: "test_three", Type: sqlite.SQLITE_BLOB},
-			{Name: "test_arg", Type: sqlite.SQLITE_TEXT, Hidden: true},
+			{Name: "test_one", Type: "TEXT"},
+			{Name: "test_two", Type: "INTEGER"},
+			{Name: "test_three", Type: "BLOB"},
+			{Name: "test_arg", Type: "TEXT", Hidden: true},
 		},
 	}
 


### PR DESCRIPTION
allow column types to be specified by a string rather than from the set of "known" SQLite types